### PR TITLE
Add French translation

### DIFF
--- a/locale/fr/config.cfg
+++ b/locale/fr/config.cfg
@@ -1,0 +1,66 @@
+[entity-name]
+	small-armoured-biter=Petit fracasseur
+	small_armoured-corpse=Cadavre de petit fracasseur
+	medium-armoured-biter=Fracasseur
+	medium-armoured-corpse=Cadavre de fracasseur
+	big-armoured-biter=Gros fracasseur
+	big-armoured-corpse=Cadavre de gros fracasseur
+	behemoth-armoured-biter=Énorme fracasseur
+	behemoth-armoured-corpse=Cadavre d'énorme fracasseur
+	armoured-biter-spawner=Nid de fracasseur
+	armoured-biter-spawner-corpse=Cadavre de nid de fracasseur
+	leviathan-armoured-biter=Fracasseur colossal
+	leviathan-armoured-corpse=Cadavre de fracasseur colossal
+[entity-description]
+	small-armoured-biter=
+	medium-armoured-biter=
+	big-armoured-biter=
+	behemoth-armoured-biter=
+	leviathan-armoured-biter=
+[mod-setting-name]
+	ab-small-armoured-biter-health=Santé du petit fracasseur
+	ab-small-armoured-biter-resistances=Résistances du petit fracasseur
+	ab-small-armoured-biter-spawn-probability=Probabilité d'apparition de petit fracasseur
+	ab-small-armoured-biter-color-primary=Couleur primaire du petit fracasseur
+	ab-small-armoured-biter-color-secondary=Couleur secondaire du petit fracasseur
+	ab-medium-armoured-biter-health=Santé du fracasseur
+	ab-medium-armoured-biter-resistances=Résistances du fracasseur
+	ab-medium-armoured-biter-spawn-probability=Probabilité d'apparition de fracasseur
+	ab-medium-armoured-biter-color-primary=Couleur primaire du fracasseur
+	ab-medium-armoured-biter-color-secondary=Couleur secondaire du fracasseur
+	ab-big-armoured-biter-health=Santé du gros fracasseur
+	ab-big-armoured-biter-resistances=Résistances du gros fracasseur
+	ab-big-armoured-biter-spawn-probability=Probabilité d'apparition de gros fracasseur
+	ab-big-armoured-biter-color-primary=Couleur primaire du gros fracasseur
+	ab-big-armoured-biter-color-secondary=Couleur secondaire du gros fracasseur
+	ab-behemoth-armoured-biter-health=Santé de l'énorme fracasseur
+	ab-behemoth-armoured-biter-resistances=Résistances de l'énorme fracasseur
+	ab-behemoth-armoured-biter-spawn-probability=Probabilité d'apparition d'énorme fracasseur
+	ab-behemoth-armoured-biter-color-primary=Couleur primaire de l'énorme fracasseur
+	ab-behemoth-armoured-biter-color-secondary=Couleur secondaire de l'énorme fracasseur
+	ab-leviathan-armoured-biter-health=Santé du fracasseur colossal
+	ab-leviathan-armoured-biter-resistances=Résistances du fracasseur colossal
+	ab-leviathan-armoured-biter-spawn-probability=Probabilité d'apparition de fracasseur colossal
+	ab-leviathan-armoured-biter-color-primary=Couleur primaire du fracasseur colossal
+	ab-leviathan-armoured-biter-color-secondary=Couleur secondaire du fracasseur colossal
+	ab-enable-nest=Activer les nids de fracasseurs
+	ab-disable-moisture-check=Ignorer l'humidité lors de la création de nids de fracasseurs
+
+[mod-setting-description]
+	ab-small-armoured-biter-health=Par défaut 100 % ; un pourcentage plus élevé rendra les petits fracasseurs plus résistants.
+	ab-small-armoured-biter-resistances=Par défaut 100 % ; un pourcentage plus élevé rendra les petits fracasseurs plus résistants.
+	ab-small-armoured-biter-spawn-probability=100 % signifie que les petits fracasseurs ont la même probabilité d'apparaître que les petits déchiqueteurs ; un pourcentage plus élevé les rendra plus propices à apparaître que les petits déchiqueteurs.
+	ab-medium-armoured-biter-health=Par défaut 100 % ; un pourcentage plus élevé rendra les fracasseurs plus résistants.
+	ab-medium-armoured-biter-resistances=Par défaut 100 % ; un pourcentage plus élevé rendra les fracasseurs plus résistants.
+	ab-medium-armoured-biter-spawn-probability=100 % signifie que les fracasseurs ont la même probabilité d'apparaître que les déchiqueteurs ; un pourcentage plus élevé les rendra plus propices à apparaître que les déchiqueteurs.
+	ab-big-armoured-biter-health=Par défaut 100 % ; un pourcentage plus élevé rendra les gros fracasseurs plus résistants.
+	ab-big-armoured-biter-resistances=Par défaut 100 % ; un pourcentage plus élevé rendra les gros fracasseurs plus résistants.
+	ab-big-armoured-biter-spawn-probability=100 % signifie que les gros fracasseurs ont la même probabilité d'apparaître que les gros déchiqueteurs ; un pourcentage plus élevé les rendra plus propices à apparaître que les gros déchiqueteurs.
+	ab-behemoth-armoured-biter-health=Par défaut 100 % ; un pourcentage plus élevé rendra les énormes fracasseurs plus résistants.
+	ab-behemoth-armoured-biter-resistances=Par défaut 100 % ; un pourcentage plus élevé rendra les énormes fracasseurs plus résistants.
+	ab-behemoth-armoured-biter-spawn-probability=100 % signifie que les énormes fracasseurs ont la même probabilité d'apparaître que les énormes déchiqueteurs ; un pourcentage plus élevé les rendra plus propices à apparaître que les énormes déchiqueteurs.
+	ab-leviathan-armoured-biter-health=Par défaut 100 % ; un pourcentage plus élevé rendra les fracasseurs colossaux plus résistants.
+	ab-leviathan-armoured-biter-resistances=Par défaut 100 % ; un pourcentage plus élevé rendra les fracasseurs colossaux plus résistants.
+	ab-leviathan-armoured-biter-spawn-probability=Par défaut 50 %.
+	ab-enable-nest=Si désactivé, les fracasseurs apparaîtront via les nids de déchiqueteurs standards (incompatible avec Rampant).
+	ab-disable-moisture-check=Si désactivé, les nids de fracasseurs apparaîtront (lors des expansions) selon les mêmes conditions que les autres nids (incompatible avec Rampant).


### PR DESCRIPTION
Hello!

Really liking your mod, I did a French translation of it.
Apart from the English-to-French translation, I took some liberties to improve the translated experience, which I would like you to tell me if you agree with them or not.

# Snappers become *Fracasseurs*

In French, Biters have been translated to *Déchiqueteurs* (shredders), and Spitters to *Cracheurs* (literal translation).
Since Snappers are powerful and can smash through anything, I decided to do the same as with Biters and translate their name to a destructive one instead of literal, in this case *Fracasseurs* (smashers/shatterers).

# Entities descriptions removed
I removed the entities descriptions, as the vanilla enemies do not have any.
If an entity has a description, it shows up in-game in the tooltip on the right.
In order to make the Snappers feel more like they were always a genuine part of the vanilla game, I decided (at least for French) to be coherent with the vanilla enemies and remove entities descriptions.

# Options renamed for clarity
I had trouble understanding what the options meant, so after figuring them out I decided to change a bit the translation to make them clearer:

| Original | French translation | English equivalent | Notes |
|---|---|---|---|
| *Change max health (100% is the default value, higher percentage makes the enemies tougher)* | *Par défaut 100 % ; un pourcentage plus élevé rendra les fracasseurs plus résistants.* | *100 % by default; a higher percentage will make the snappers tougher.* | Removes redundancy with the option's label that already mentions changing max health. I did the same thing for the resistances and spawn rate probability options, and I mentioned the specific snapper (small, normal, behemoth, etc.) in each description |
| *Enable armoured biters nest* | *Activer les nids de fracasseurs* | *Enable snappers nests* | Explicitly references the snappers |
| *If disabled, they will spawn on vanilla nest (Not compatible with Rampant)* | *Si désactivé, les fracasseurs apparaîtront via les nids de déchiqueteurs standards (incompatible avec Rampant).* | *If disabled, snappers will spawn via the standard vanilla biter nests (not compatible with Rampant).* | Makes clearer which of the vanilla nests will be used |
|  *Disable moisture check on enemy spawning* |  *Ignorer l'humidité lors de la création de nids de fracasseurs* | *Ignore moisture during snappers nests creation* | Explicitly states that this option influences the snapper nests expansion mechanics |
| *If disabled, it will spawn as any other nest (Not compatible with Rampant)* | *Si désactivé, les nids de fracasseurs apparaîtront (lors des expansions) selon les mêmes conditions que les autres nids (incompatible avec Rampant).** | *If disabled, snapper nests will spawn (during expansions) following the same conditions as other nests (not compatible with Rampant).* | Explicitly states that this option influences the snapper nests expansion mechanics |

I hope that you will like this translation, and that you will consider adding it to the mod.

I am happy to discuss any change you would see fit.