### PR TITLE
Fix biters not inheriting default ai settings, causing lag

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -3,6 +3,7 @@ local setting_utils = require("setting-utils")
 local sounds = require("__base__.prototypes.entity.sounds")
 local ab_enemy_autoplace = require("armoured-autoplace")
 local enemy_autoplace = require("__base__.prototypes.entity.enemy-autoplace-utils")
+local biter_ai_settings = require("__base__.prototypes.entity.biter-ai-settings")
 
 small_armoured_scale = 0.5
 small_armoured_tint1 = settings.startup["ab-small-armoured-biter-color-primary"].value


### PR DESCRIPTION
This global was removed.

The settings armoured biters are missing are thus:

```lua
{ destroy_when_commands_fail = true, allow_try_return_to_spawner = true }
```

`allow_try_return_to_spawner`, specifically, causes biters that are not able to attack to try to return to their spawner, or to despawn as a failsafe. Without this, large deathworld games pile up active armoured biters not going anywhere, slowly accumulating massive amounts of lag.

`destroy_when_commands_fail` is another failsafe for stuck units, so also bad to be missing.

This reduced the active Units in our SE Death World save from 8500 to 900 (10ms -> 1ms)

Should fix these people as well: https://mods.factorio.com/mod/ArmouredBiters/discussion/674c7bda9790762c7be828a2